### PR TITLE
お気に入り機能の実装とユーザー情報内容更新パスワード部分を変更

### DIFF
--- a/prisma/migrations/20230302072423_/migration.sql
+++ b/prisma/migrations/20230302072423_/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - The primary key for the `Favorite` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[id]` on the table `Favorite` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Favorite" DROP CONSTRAINT "Favorite_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE DOUBLE PRECISION;
+DROP SEQUENCE "Favorite_id_seq";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Favorite_id_key" ON "Favorite"("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,9 +48,9 @@ model Item {
 }
 
 model Favorite {
-  id        Int      @id @default(autoincrement())
+  id        Float    @unique   
   itemId Int[]
-  userId    Int
+  userId    Int      
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -58,7 +58,7 @@ model Favorite {
 
 model Cart {
   id       Int    @id @default(autoincrement())
-  userId   Int
+  userId   Int    
   itemId   Int
   imageUrl String
   name     String
@@ -69,7 +69,7 @@ model Cart {
 
 model SubscriptionCart {
   id       Int    @id @default(autoincrement())
-  userId   Int
+  userId   Int    
   itemId   Int
   imageUrl String
   flavor   String

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -19,7 +19,14 @@ export class AuthService {
   // ユーザー新規作成機能
   async signUp(dto: AuthDto): Promise<Msg> {
     console.log(dto);
-    const hashed = await bcrypt.hash(dto.password, 12);
+    let hashed = '';
+    if (dto.password === dto.passwordConfirmation) {
+      hashed = await bcrypt.hash(dto.password, 12);
+    } else {
+      throw new ForbiddenException(
+        'password and passwordConfimation are diffent',
+      );
+    }
     try {
       await this.prisma.user.create({
         data: {

--- a/src/favorite/dto/into-favorite.dto.ts
+++ b/src/favorite/dto/into-favorite.dto.ts
@@ -1,7 +1,9 @@
-import { IsOptional } from 'class-validator';
+import { IsNotEmpty, IsArray } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class IntoFavoriteDto {
-  userId?: number;
-  itemIdFav?: number;
-  id: number;
+  @IsNotEmpty()
+  @Type(() => Number)
+  @IsArray()
+  itemId?: number[];
 }

--- a/src/favorite/favorite.controller.ts
+++ b/src/favorite/favorite.controller.ts
@@ -1,4 +1,29 @@
-import { Controller } from '@nestjs/common';
+import { FavoriteService } from './favorite.service';
+import { Request } from 'express';
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { IntoFavoriteDto } from './dto/into-favorite.dto';
+import { User } from '@prisma/client';
+import { Delete, Post } from '@nestjs/common/decorators';
 
 @Controller('favorite')
-export class FavoriteController {}
+export class FavoriteController {
+  constructor(private readonly favoriteService: FavoriteService) {}
+
+  @Patch()
+  updateFavorite(@Req() req: Request, @Body() dto: IntoFavoriteDto) {
+    // : Promise<Omit<User, 'hashedPassword'>>
+    const idToNumber = Number(req.cookies.id);
+    return this.favoriteService.intoFavorite(idToNumber, dto);
+  }
+
+  @Get()
+  getUserFavorites(@Req() req: Request) {
+    const idToNumber = Number(req.cookies.id);
+    return this.favoriteService.getUserFavorites(idToNumber);
+  }
+
+  // @Delete()
+  // deleteUserFavs(@Req() req:Request){
+
+  // }
+}

--- a/src/favorite/favorite.module.ts
+++ b/src/favorite/favorite.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from 'src/prisma/prisma.module';
 import { FavoriteController } from './favorite.controller';
 import { FavoriteService } from './favorite.service';
 
 @Module({
   controllers: [FavoriteController],
   providers: [FavoriteService],
+  imports: [PrismaModule],
 })
 export class FavoriteModule {}

--- a/src/favorite/favorite.service.ts
+++ b/src/favorite/favorite.service.ts
@@ -1,4 +1,42 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { IntoFavoriteDto } from './dto/into-favorite.dto';
 
 @Injectable()
-export class FavoriteService {}
+export class FavoriteService {
+  constructor(private prisma: PrismaService) {}
+
+  async intoFavorite(userId: number, dto: IntoFavoriteDto) {
+    const toNumberItemId = Number(dto.itemId[0]);
+    const favorite = await this.prisma.favorite.upsert({
+      where: {
+        id: Number(`${userId}.${toNumberItemId}`),
+        // userId: userId,
+      },
+      update: {
+        // id: toNumberItemId,
+        id: Number(`${userId}.${toNumberItemId}`),
+        itemId: Number(dto.itemId),
+      },
+      create: {
+        userId: userId,
+        id: Number(`${userId}.${toNumberItemId}`),
+        itemId: Number(dto.itemId),
+      },
+    });
+    return console.log(favorite);
+  }
+
+  async getUserFavorites(loginUser: number) {
+    const favoritesUser = await this.prisma.favorite.findMany({
+      where: {
+        userId: loginUser,
+      },
+    });
+    if (!favoritesUser) {
+      throw new UnauthorizedException('ユーザー情報の取得に失敗しました');
+    }
+    console.log(favoritesUser);
+    return favoritesUser.map((item) => item.itemId[0]);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  // app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   app.enableCors({
     credentials: true,
     origin: ['http://localhost:3000'],

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -7,7 +7,7 @@ export class UpdateUserDto {
   @IsOptional()
   firstName?: string;
   lastName?: string;
-  firsrNameKana?: string;
+  firstNameKana?: string;
   lastNameKana?: string;
   middleName?: string;
   email?: string;
@@ -17,4 +17,6 @@ export class UpdateUserDto {
   aza?: string;
   building?: string;
   tel?: string;
+  password?: string;
+  passwordConfirmation?: string;
 }


### PR DESCRIPTION
- お気に入り機能の実装
```
- お気に入りの追加（同じ商品はdbに入れない）
- お気に入り情報の取り出し
```

- ユーザー情報内容更新機能の一部内容変更
パスワードの変更ができないようになっていた部分を、できるよう変更